### PR TITLE
Add darkreader-lock meta tag

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
+        <meta name="darkreader-lock" />
         <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Deadlock - Crosshair generator</title>


### PR DESCRIPTION
Adds meta tag to index.html to disable [DarkReader](https://chromewebstore.google.com/detail/dark-reader/eimadpbcbfnmbkopoojfekhnkhdbieeh) so colors don't get inverted when using the popular extension.

Relevant: 
https://github.com/darkreader/darkreader/discussions/6868
https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-statically